### PR TITLE
feat: export operations interface

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -1,7 +1,8 @@
 import LibLogger from "./logger.js";
 import { Item } from "@fjell/core";
 import { Instance as BaseInstance, Coordinate, createInstance as createBaseInstance, Registry } from "@fjell/registry";
-import { Operations, Options } from "@fjell/lib";
+import type { Operations } from "./Operations.js";
+import { Options } from "@fjell/lib";
 import { ItemRouter } from "./ItemRouter.js";
 
 const logger = LibLogger.get("Instance");

--- a/src/InstanceFactory.ts
+++ b/src/InstanceFactory.ts
@@ -1,7 +1,8 @@
 import { Item } from "@fjell/core";
 import { ItemRouter } from "./ItemRouter.js";
 import { InstanceFactory as BaseInstanceFactory, Registry, RegistryHub } from "@fjell/registry";
-import { Operations, Options } from "@fjell/lib";
+import type { Operations } from "./Operations.js";
+import { Options } from "@fjell/lib";
 import { createInstance, Instance } from "./Instance.js";
 import { Coordinate } from "@fjell/registry";
 import LibLogger from "./logger.js";

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -1,0 +1,1 @@
+export type { Operations } from "@fjell/lib";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from "./PItemRouter.js";
 export * from './Instance.js';
 export * from './InstanceFactory.js';
 export * from './Registry.js';
+export type { Operations } from './Operations.js';

--- a/tests/Instance.test.ts
+++ b/tests/Instance.test.ts
@@ -5,7 +5,8 @@ import { createInstance, isInstance } from '../src/Instance';
 import { ItemRouter } from '../src/ItemRouter';
 import { Item } from '@fjell/core';
 import { Coordinate, Registry } from '@fjell/registry';
-import { Operations, Options } from '@fjell/lib';
+import type { Operations } from '../src/Operations';
+import { Options } from '@fjell/lib';
 
 // Mock the logger
 vi.mock('@fjell/logging', () => ({

--- a/tests/InstanceFactory.test.ts
+++ b/tests/InstanceFactory.test.ts
@@ -5,7 +5,8 @@ import { createInstance } from '../src/Instance';
 import { ItemRouter } from '../src/ItemRouter';
 import { Item } from '@fjell/core';
 import { Coordinate, Registry, RegistryHub } from '@fjell/registry';
-import { Operations, Options } from '@fjell/lib';
+import type { Operations } from '../src/Operations';
+import { Options } from '@fjell/lib';
 
 // Mock the logger
 vi.mock('../src/logger', () => ({


### PR DESCRIPTION
## Summary
- export Operations interface from new file
- update Instance and InstanceFactory to use local operations type
- point tests at new module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ac12c3d8832585835a787be30e57